### PR TITLE
Use fetch API instead XMLHttpRequest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,6 +6,7 @@
     ]
   },
   "manifest_version": 2,
+  "minimum_chrome_version": "45",
   "name": "Eyeo helpers",
   "description": "Helpful utilities to make our jobs at Eyeo easier",
   "icons": {

--- a/src/tracUserSuggestion.js
+++ b/src/tracUserSuggestion.js
@@ -3,16 +3,16 @@ var users;
 // Grab a list of all users
 function fetch_users()
 {
-  var request = new XMLHttpRequest();
-  request.onreadystatechange = function() {
-    if (request.readyState === 4)
-      if (request.status > 199 && request.status < 300)
-        users = request.responseText.split("\n");
-      else if (!request.status && !request.responseText)
-        window.setTimeout(fetch_users, 30000);
-  };
-  request.open("GET", "https://issues.adblockplus.org/subjects", true);
-  request.send(null);
+  fetch("https://issues.adblockplus.org/subjects").then(
+    response => response.ok ? response.text() : Promise.reject()
+  ).then(
+    text => {
+      users = text.split("\n");
+    },
+    () => {
+      setTimeout(fetch_users, 30000);
+    }
+  );
 }
 fetch_users();
 


### PR DESCRIPTION
The code fetching Trac users can be simplified using the `fetch` API and promises. Also note that previously you didn't handle all error scenarios. That is done now as well.