### PR TITLE
Close XSS vulnerability when transforming review titles

### DIFF
--- a/src/linkifyIssueNumbers.js
+++ b/src/linkifyIssueNumbers.js
@@ -7,16 +7,13 @@
   // Find sections with issue IDs and then linkify each issue ID.
   let sectionRe = /#\d+|Issues?\s+#?(?:\d+.\s*)+/gi;
   let header = document.querySelector("body div h2");
-  let decoratedNode = document.createElement("span");
-  decoratedNode.innerHTML = header.removeChild(header.lastChild).textContent
-    .replace(
-      sectionRe,
-      matchingString => matchingString.replace(
-        /\d+/g,
-        issueID => "<a href=\"https://issues.adblockplus.org/ticket/" +
-                   issueID + "\">" + issueID + "</a>"
-      )
-    );
-  header.appendChild(decoratedNode);
+  header.innerHTML = header.innerHTML.replace(
+    sectionRe,
+    matchingString => matchingString.replace(
+      /\d+/g,
+      issueID => "<a href=\"https://issues.adblockplus.org/ticket/" +
+                 issueID + "\">" + issueID + "</a>"
+    )
+  );
 }());
 


### PR DESCRIPTION
When injecting links to the issue in the title of reviews on Rietveld, you get the plain text (with `<` and `>` unescaped) and after replacing the issue number with a link, you treat the result as HTML (by assigning it to the `innerHTML` attribute), which essentially unescapes all markup that was previously properly escaped.

I first noticed that issue, by random strings enclosed in `<` and `>` becoming invisible, in the title. Finally, I was able to create a [proof of concept](https://codereview.adblockplus.org/29717633/) that allows me to run arbitrary JavaScript in a code review, when using the eyeo-helpers extension, through a maliciously crafted title.

This pull request fixes this vulnerability by retrieving the text, to perform the replacement on, through the `innerHTML` property, so that no markup is getting unescaped.